### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/R/compare_fit.R
+++ b/R/compare_fit.R
@@ -82,7 +82,7 @@ plot_fitcmp <- function(fitcmp) {
     ggplot2::geom_bar(stat = "identity", fill = NA, color = "black") +
     ggplot2::facet_grid(count ~ model) +
     ggplot2::geom_point(ggplot2::aes(x = x, y = n, color = "red")) +
-    ggplot2::scale_color_discrete(guide = FALSE) +
+    ggplot2::scale_color_discrete(guide = "none") +
     ggplot2::theme_bw()
 }
 

--- a/tests/testthat/testing.R
+++ b/tests/testthat/testing.R
@@ -42,7 +42,11 @@ test_that("plot_fit", {
   expect_equal(cmp[1,5], 3.639184)
   # expect_equal(cmp[6,5], NA)
   expect_equal(cmp[18,5], 1.819557, tolerance = 3.65e-07)
-  expect_equal(p$labels[[1]], "x")
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    expect_equal(ggplot2::get_labs(p)$x, "x")
+  } else {
+    expect_equal(p$labels[[1]], "x")
+  }
   expect_equal(p$coordinates$clip, "on")
   expect_equal(p$coordinates$limits$x, NULL)
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the countfitteR package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
In addition, some deprecated functionality is avoided.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun